### PR TITLE
Fix blog link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Hey :wave:, 
 
-This is the repository for my [blog](will.townsend.io)
+This is the repository for my [blog](//will.townsend.io)
 
 ## Running in development
 


### PR DESCRIPTION
The current blog link in _README.md_ `[blog](will.townsend.io)` actually sends the user to `https://github.com/wtsnz/wtsnz.github.io/blob/master/will.townsend.io` instead if `will.townsend.io`